### PR TITLE
Falsche Parent-Version gefixt

### DIFF
--- a/ee-demos-jsf/pom.xml
+++ b/ee-demos-jsf/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>de.gedoplan.buch</groupId>
     <artifactId>ee-demos</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>7.0.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>ee-demos-jsf</artifactId>


### PR DESCRIPTION
Der Maven-Build des Branches _javaee7ausg2_ schlägt fehl, weil _ee-demos-jsf_ auf einen Parent in der falschen Version zeigt:

> $ mvn validate
> [...]
> [ERROR] [ERROR] Some problems were encountered while processing the POMs:
> [FATAL] Non-resolvable parent POM for de.gedoplan.buch:ee-demos-jsf:[unknown-version]: Could not find artifact de.gedoplan.buch:ee-demos:pom:7.0.0-SNAPSHOT in snapshots (...) and 'parent.relativePath' points at wrong local POM @ line 5, column 11

Du kannst die Änderung auch gerne selbst committen, falls Du lieber keine Fremdbeiträge haben möchtest.
